### PR TITLE
Report Bazel version as per .bazelversion file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ development environment:
 bazel --version
 ```
 
-This should report back `bazel 7.3.1`.
+This should report back `bazel 7.3.2`.
 
 ## Devcontainer Compatibility
 


### PR DESCRIPTION
This is what we have in the `.bazelversion` file: https://github.com/tweag/bazel-workshop-2024/blob/main/.bazelversion#L1